### PR TITLE
[feat] support vLLM and modal serving backends

### DIFF
--- a/gamingagent/agents/base_agent.py
+++ b/gamingagent/agents/base_agent.py
@@ -30,6 +30,8 @@ class BaseAgent(ABC):
             cache_dir=None,
             custom_modules=None, 
             observation_mode="vision",    # change the abstraction to with or without image
+            vllm_url=None,
+            modal_url=None,
         ):
         """
         Initialize the agent with base parameters and modules.
@@ -51,6 +53,10 @@ class BaseAgent(ABC):
         self.use_custom_prompt = use_custom_prompt
         self.max_memory = max_memory
         self.observation_mode = observation_mode
+
+        # Serving-related arguments
+        self.vllm_url = vllm_url
+        self.modal_url = modal_url
         
         # Set up cache directory following the specified pattern
         if cache_dir is None:
@@ -148,7 +154,7 @@ class BaseAgent(ABC):
         # Always initialize base module
         # to support without-harness decision-making
         
-        # TODO: make arguments configurable
+        # TODO: make token_limit and reasoning_effort configurable
         modules["base_module"] = BaseModule(
             model_name=self.model_name,
             cache_dir=self.cache_dir,
@@ -156,7 +162,9 @@ class BaseAgent(ABC):
             prompt=self.config["base_module"]["prompt"],
             observation_mode=self.observation_mode,
             token_limit=100000,
-            reasoning_effort="high"
+            reasoning_effort="high",
+            vllm_url=self.vllm_url,
+            modal_url=self.modal_url
         )
 
         # Initialize perception, memory, and reasoning modules if using harness
@@ -195,7 +203,7 @@ class BaseAgent(ABC):
                     max_memory=self.max_memory
                 )
             
-            # TODO (lanxiang): make reasoning efforts configurable
+            # TODO: make token_limit and reasoning_effort configurable
             # Reasoning module
             if custom_modules and "reasoning_module" in custom_modules:
                 reasoning_cls = custom_modules["reasoning_module"]
@@ -204,7 +212,9 @@ class BaseAgent(ABC):
                     observation_mode=self.observation_mode,
                     cache_dir=self.cache_dir,
                     system_prompt=self.config["reasoning_module"]["system_prompt"],
-                    prompt=self.config["reasoning_module"]["prompt"]
+                    prompt=self.config["reasoning_module"]["prompt"],
+                    vllm_url=self.vllm_url,
+                    modal_url=self.modal_url
                 )
             else:
                 # Can't use default ReasoningModule as it's abstract

--- a/gamingagent/modules/base_module.py
+++ b/gamingagent/modules/base_module.py
@@ -26,7 +26,9 @@ class BaseModule(CoreModule):
                 system_prompt="", 
                 prompt="", 
                 token_limit=100000, 
-                reasoning_effort="high"
+                reasoning_effort="high",
+                vllm_url=None,
+                modal_url=None
         ):
         """
         Initialize the base module.
@@ -50,7 +52,9 @@ class BaseModule(CoreModule):
             prompt=prompt,
             cache_dir=cache_dir,
             token_limit=token_limit,
-            reasoning_effort=reasoning_effort
+            reasoning_effort=reasoning_effort,
+            vllm_url=vllm_url,
+            modal_url=modal_url
         )
         self.observation_mode = observation_mode
         self.observation = Observation()  # Observation data class

--- a/gamingagent/modules/core_module.py
+++ b/gamingagent/modules/core_module.py
@@ -296,7 +296,9 @@ class CoreModule(ABC):
                 prompt="", 
                 cache_dir="cache",
                 token_limit=100000, 
-                reasoning_effort="medium"
+                reasoning_effort="medium",
+                vllm_url=None,
+                modal_url=None
         ):
         """
         Initialize the core module with basic parameters.
@@ -319,7 +321,11 @@ class CoreModule(ABC):
         self.reasoning_effort = reasoning_effort
         
         # Initialize API manager
-        self.api_manager = APIManager(game_name=module_name.replace("_module", ""))
+        self.api_manager = APIManager(
+            game_name=module_name.replace("_module", ""), 
+            vllm_url=vllm_url,
+            modal_url=modal_url
+        )
         
         # Create cache directory if it doesn't exist
         os.makedirs(cache_dir, exist_ok=True)

--- a/gamingagent/modules/reasoning_module.py
+++ b/gamingagent/modules/reasoning_module.py
@@ -26,7 +26,9 @@ class ReasoningModule(CoreModule):
                 use_memory=True,
                 use_cot=True,
                 token_limit=100000, 
-                reasoning_effort="high"
+                reasoning_effort="high",
+                vllm_url=None,
+                modal_url=None
         ):
         """
         Initialize the reasoning module.
@@ -52,7 +54,9 @@ class ReasoningModule(CoreModule):
             prompt=prompt,
             cache_dir=cache_dir,
             token_limit=token_limit,
-            reasoning_effort=reasoning_effort  # Always use high reasoning effort
+            reasoning_effort=reasoning_effort,  # Always use high reasoning effort
+            vllm_url=vllm_url,
+            modal_url=modal_url
         )
 
         self.observation_mode = observation_mode
@@ -154,7 +158,7 @@ class ReasoningModule(CoreModule):
             image_path=image_path,
             thinking=True,
             reasoning_effort=self.reasoning_effort,
-            token_limit=self.token_limit
+            token_limit=self.token_limit,
         )
         
         return response
@@ -188,7 +192,7 @@ class ReasoningModule(CoreModule):
             prompt=user_prompt,
             thinking=True,
             reasoning_effort=self.reasoning_effort,
-            token_limit=self.token_limit
+            token_limit=self.token_limit,
         )
         
         return response

--- a/lmgame-bench/custom_runner.py
+++ b/lmgame-bench/custom_runner.py
@@ -54,6 +54,20 @@ def parse_arguments(defaults_map=None, argv_to_parse=None):
     parser.add_argument("--seed", type=int, default=None, help="Random seed for environment.")
     # Env type is fixed to custom gym for this runner
 
+    # Serving-related arguments
+    parser.add_argument(
+        "--modal_url",
+        type=str,
+        default=None,
+        help="Optional URL for a Modal‑hosted inference endpoint passed to BaseAgent.",
+    )
+    parser.add_argument(
+        "--vllm_url",
+        type=str,
+        default=None,
+        help="Optional URL for a vLLM inference endpoint passed to BaseAgent.",
+    )
+
     if defaults_map:
         parser.set_defaults(**defaults_map)
         
@@ -586,7 +600,9 @@ def main():
         max_memory=args.max_memory, 
         custom_modules=custom_modules_for_agent,
         observation_mode=args.observation_mode,
-        cache_dir=runner_log_dir_base # Ensure agent uses the same cache_dir
+        cache_dir=runner_log_dir_base,
+        vllm_url=args.vllm_url,
+        modal_url=args.modal_url
     )
     
     # runner_log_dir = agent.cache_dir # Agent already sets its cache_dir, this can be removed or used for verification

--- a/tools/modal/launch_instance.sh
+++ b/tools/modal/launch_instance.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# === CONFIGURATION ===
+export N_GPU=8
+export GPU_TYPE="H100"
+export MODEL_NAME="google/gemma-3-27b-it"
+export MODEL_REVISION="main"
+export API_KEY="DUMMY_TOKEN"
+export VLLM_PORT=8000
+export HF_CACHE_VOL="huggingface-cache"
+export VLLM_CACHE_VOL="vllm-cache"
+export MINUTES=60
+export HF_TOKEN="your_huggingface_token"  # Replace with your actual Hugging Face token
+
+# === DEPLOY MODAL INSTANCE ===
+modal deploy serve_instance.py

--- a/tools/modal/serve_instance.py
+++ b/tools/modal/serve_instance.py
@@ -1,0 +1,72 @@
+import modal
+import os
+
+# --------
+# Get config from environment variables
+# --------
+def get_env_args():
+    return {
+        "gpus": int(os.environ.get("N_GPU", 8)),
+        "gpu_type": os.environ.get("GPU_TYPE", "H100"),
+        "model": os.environ.get("MODEL_NAME", "google/gemma-3-27b-it"),
+        "revision": os.environ.get("MODEL_REVISION", "005ad3404e59d6023443cb575daa05336842228a"),
+        "api_key": os.environ.get("API_KEY", "DUMMY_TOKEN"),
+        "port": int(os.environ.get("VLLM_PORT", 8000)),
+        "hf_cache_vol": os.environ.get("HF_CACHE_VOL", "huggingface-cache"),
+        "vllm_cache_vol": os.environ.get("VLLM_CACHE_VOL", "vllm-cache"),
+        "minutes": int(os.environ.get("MINUTES", 60)),
+        "hf_token": str(os.environ.get("HF_TOKEN", "your_huggingface_token")),
+    }
+
+args = get_env_args()
+
+# --------
+# Modal image definition
+# --------
+vllm_image = (
+    modal.Image.debian_slim(python_version="3.12")
+    .pip_install(
+        "vllm==0.8.2",
+        "huggingface_hub[hf_transfer]==0.32.0",
+        extra_index_url="https://flashinfer.ai/whl/cu124/torch2.5",
+    )
+    .env({"HF_HUB_ENABLE_HF_TRANSFER": "1", "VLLM_USE_V1": "1"})
+)
+
+hf_cache_vol = modal.Volume.from_name(args["hf_cache_vol"], create_if_missing=True)
+vllm_cache_vol = modal.Volume.from_name(args["vllm_cache_vol"], create_if_missing=True)
+
+app = modal.App("vllm-serving-engine-gemma3-27b-it-8h100-test")
+@app.function(
+    image=vllm_image,
+    gpu=f"{args['gpu_type']}:{args['gpus']}",
+    scaledown_window=60 * args['minutes'],
+    timeout=120 * args['minutes'],
+    volumes={
+        "/root/.cache/huggingface": hf_cache_vol,
+        "/root/.cache/vllm": vllm_cache_vol,
+    },
+    secrets=[modal.Secret.from_name("lmgame-secret")]
+)
+@modal.concurrent(max_inputs=100)
+@modal.web_server(port=args['port'], startup_timeout=120 * args['minutes'])
+def serve():
+    import subprocess
+
+    hf_cmd = f"huggingface-cli login --token {args['hf_token']}"
+    vllm_cmd = (
+        f"vllm serve "
+        f"--uvicorn-log-level=info "
+        f"{args['model']} "
+        f"--revision {args['revision']} "
+        f"--enable-chunked-prefill "
+        f"--tensor_parallel_size {args['gpus']} "
+        f"--host 0.0.0.0 "
+        f"--port {args['port']} "
+        f"--api-key {os.environ['LMGAME_SECRET']}"
+    )
+
+    full_cmd = f"{hf_cmd} && {vllm_cmd}"
+
+    print("Running merged command:", full_cmd)
+    proc = subprocess.Popen(full_cmd, shell=True)

--- a/tools/serving/api_providers.py
+++ b/tools/serving/api_providers.py
@@ -1,5 +1,9 @@
 import os
 
+import time
+import functools
+import httpx
+
 from openai import OpenAI
 import anthropic
 import google.generativeai as genai
@@ -8,8 +12,43 @@ from together import Together
 
 import requests
 
+def retry_on_overload(func):
+    """
+    A decorator to retry a function call on anthropic.APIStatusError with 'overloaded_error'.
+    It uses exponential backoff with jitter.
+    """
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        max_retries = 5
+        base_delay = 2  # seconds
+        for attempt in range(max_retries):
+            try:
+                return func(*args, **kwargs)
+            except anthropic.APIStatusError as e:
+                if e.body and e.body.get('error', {}).get('type') == 'overloaded_error':
+                    if attempt < max_retries - 1:
+                        delay = base_delay * (2 ** attempt) + (os.urandom(1)[0] / 255.0)
+                        print(f"Anthropic API overloaded. Retrying in {delay:.2f} seconds... (Attempt {attempt + 1}/{max_retries})")
+                        time.sleep(delay)
+                    else:
+                        print(f"Anthropic API still overloaded after {max_retries} attempts. Raising the error.")
+                        raise
+                else:
+                    # Re-raise if it's not an overload error
+                    raise
+            except httpx.RemoteProtocolError as e:
+                if attempt < max_retries - 1:
+                    delay = base_delay * (2 ** attempt) + (os.urandom(1)[0] / 255.0)
+                    print(f"Streaming connection closed unexpectedly. Retrying in {delay:.2f} seconds... (Attempt {attempt + 1}/{max_retries})")
+                    time.sleep(delay)
+                else:
+                    print(f"Streaming connection failed after {max_retries} attempts. Raising the error.")
+                    raise
+    return wrapper
+
+@retry_on_overload
 def anthropic_completion(system_prompt, model_name, base64_image, prompt, thinking=False, token_limit=30000):
-    print(f"anthropic vision-text activated... thinking: f{thinking}")
+    print(f"anthropic vision-text activated... thinking: {thinking}")
     client = anthropic.Anthropic(api_key=os.getenv("ANTHROPIC_API_KEY"))
     messages = [
         {
@@ -61,8 +100,13 @@ def anthropic_completion(system_prompt, model_name, base64_image, prompt, thinki
                 model=model_name, # claude-3-5-sonnet-20241022 # claude-3-7-sonnet-20250219
             ) as stream:
                 partial_chunks = []
-                for chunk in stream.text_stream:
-                    partial_chunks.append(chunk)
+                try:
+                    for chunk in stream.text_stream:
+                        partial_chunks.append(chunk)
+                except httpx.RemoteProtocolError as e:
+                    print(f"Streaming connection closed unexpectedly: {e}")
+                    # Return what we have so far
+                    return "".join(partial_chunks)
     else:
          
         with client.messages.stream(
@@ -73,13 +117,19 @@ def anthropic_completion(system_prompt, model_name, base64_image, prompt, thinki
                 model=model_name, # claude-3-5-sonnet-20241022 # claude-3-7-sonnet-20250219
             ) as stream:
                 partial_chunks = []
-                for chunk in stream.text_stream:
-                    partial_chunks.append(chunk)
+                try:
+                    for chunk in stream.text_stream:
+                        partial_chunks.append(chunk)
+                except httpx.RemoteProtocolError as e:
+                    print(f"Streaming connection closed unexpectedly: {e}")
+                    # Return what we have so far
+                    return "".join(partial_chunks)
         
     generated_code_str = "".join(partial_chunks)
     
     return generated_code_str
 
+@retry_on_overload
 def anthropic_text_completion(system_prompt, model_name, prompt, thinking=False, token_limit=30000):
     client = anthropic.Anthropic(api_key=os.getenv("ANTHROPIC_API_KEY"))
 
@@ -123,8 +173,13 @@ def anthropic_text_completion(system_prompt, model_name, prompt, thinking=False,
                 model=model_name, # claude-3-5-sonnet-20241022 # claude-3-7-sonnet-20250219
             ) as stream:
                 partial_chunks = []
-                for chunk in stream.text_stream:
-                    partial_chunks.append(chunk)
+                try:
+                    for chunk in stream.text_stream:
+                        partial_chunks.append(chunk)
+                except httpx.RemoteProtocolError as e:
+                    print(f"Streaming connection closed unexpectedly: {e}")
+                    # Return what we have so far
+                    return "".join(partial_chunks)
     else:    
         with client.messages.stream(
                 max_tokens=token_limit,
@@ -134,14 +189,19 @@ def anthropic_text_completion(system_prompt, model_name, prompt, thinking=False,
                 model=model_name, # claude-3-5-sonnet-20241022 # claude-3-7-sonnet-20250219
             ) as stream:
                 partial_chunks = []
-                for chunk in stream.text_stream:
-                    partial_chunks.append(chunk)
+                try:
+                    for chunk in stream.text_stream:
+                        partial_chunks.append(chunk)
+                except httpx.RemoteProtocolError as e:
+                    print(f"Streaming connection closed unexpectedly: {e}")
+                    # Return what we have so far
+                    return "".join(partial_chunks)
         
     generated_str = "".join(partial_chunks)
     
     return generated_str
 
-
+@retry_on_overload
 def anthropic_multiimage_completion(system_prompt, model_name, prompt, list_content, list_image_base64, token_limit=30000):
     client = anthropic.Anthropic(api_key=os.getenv("ANTHROPIC_API_KEY"))
 
@@ -196,9 +256,14 @@ def anthropic_multiimage_completion(system_prompt, model_name, prompt, list_cont
             model=model_name, # claude-3-5-sonnet-20241022 # claude-3-7-sonnet-20250219
         ) as stream:
             partial_chunks = []
-            for chunk in stream.text_stream:
-                print(chunk)
-                partial_chunks.append(chunk)
+            try:
+                for chunk in stream.text_stream:
+                    print(chunk)
+                    partial_chunks.append(chunk)
+            except httpx.RemoteProtocolError as e:
+                print(f"Streaming connection closed unexpectedly: {e}")
+                # Return what we have so far
+                return "".join(partial_chunks)
         
     generated_str = "".join(partial_chunks)
     


### PR DESCRIPTION
one of the PRs that aim to addresses issues: #58 and #11 

1. modify `api_manager.py` and `api_providers.py` to support (openai-compatible) vllm serving backends and [modal endpoints](https://modal.com/).
2. modify `customer_runner.py`, `base_agent.py`, `base_module.py`, `reasoning_module.py` and `core_module.py` to support argument passing.
3. merge with #60 
4. add example modal serving usage under `tools/modal`: gemma3-27b-it serving example.